### PR TITLE
Dependencies / Remove AppDirs

### DIFF
--- a/.idea/modules/ps2-klient.iml
+++ b/.idea/modules/ps2-klient.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="ps2-klient" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="germanno" external.system.module.version="0.1-SNAPSHOT" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="ps2-klient" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="germanno" external.system.module.version="0.2-SNAPSHOT" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../..">

--- a/.idea/modules/ps2-klient_main.iml
+++ b/.idea/modules/ps2-klient_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="ps2-klient:main" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="germanno" external.system.module.type="sourceSet" external.system.module.version="0.1-SNAPSHOT" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="ps2-klient:main" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="germanno" external.system.module.type="sourceSet" external.system.module.version="0.2-SNAPSHOT" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="kotlin-language" name="Kotlin">
       <configuration version="3" platform="JVM 1.8" useProjectSettings="false">

--- a/.idea/modules/ps2-klient_main.iml
+++ b/.idea/modules/ps2-klient_main.iml
@@ -38,17 +38,13 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Gradle: no.tornado:tornadofx:1.7.14" level="project" />
-    <orderEntry type="library" name="Gradle: net.harawata:appdirs:1.0.1" level="project" />
     <orderEntry type="library" name="Gradle: com.github.salomonbrys.kodein:kodein:4.1.0" level="project" />
     <orderEntry type="library" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.21" level="project" />
     <orderEntry type="library" name="Gradle: org.glassfish:javax.json:1.0.4" level="project" />
     <orderEntry type="library" name="Gradle: org.jetbrains.kotlin:kotlin-reflect:1.2.10" level="project" />
-    <orderEntry type="library" name="Gradle: org.slf4j:slf4j-api:1.7.25" level="project" />
-    <orderEntry type="library" name="Gradle: net.java.dev.jna:jna-platform:4.5.0" level="project" />
     <orderEntry type="library" name="Gradle: com.github.salomonbrys.kodein:kodein-core:4.1.0" level="project" />
     <orderEntry type="library" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.21" level="project" />
     <orderEntry type="library" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib:1.2.21" level="project" />
-    <orderEntry type="library" name="Gradle: net.java.dev.jna:jna:4.5.0" level="project" />
     <orderEntry type="library" name="Gradle: org.jetbrains:annotations:13.0" level="project" />
   </component>
 </module>

--- a/.idea/modules/ps2-klient_test.iml
+++ b/.idea/modules/ps2-klient_test.iml
@@ -36,19 +36,15 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="ps2-klient_main" />
     <orderEntry type="library" name="Gradle: no.tornado:tornadofx:1.7.14" level="project" />
-    <orderEntry type="library" name="Gradle: net.harawata:appdirs:1.0.1" level="project" />
     <orderEntry type="library" name="Gradle: com.github.salomonbrys.kodein:kodein:4.1.0" level="project" />
     <orderEntry type="library" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.21" level="project" />
     <orderEntry type="library" name="Gradle: junit:junit:4.12" level="project" />
     <orderEntry type="library" name="Gradle: org.glassfish:javax.json:1.0.4" level="project" />
     <orderEntry type="library" name="Gradle: org.jetbrains.kotlin:kotlin-reflect:1.2.10" level="project" />
-    <orderEntry type="library" name="Gradle: org.slf4j:slf4j-api:1.7.25" level="project" />
-    <orderEntry type="library" name="Gradle: net.java.dev.jna:jna-platform:4.5.0" level="project" />
     <orderEntry type="library" name="Gradle: com.github.salomonbrys.kodein:kodein-core:4.1.0" level="project" />
     <orderEntry type="library" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.21" level="project" />
     <orderEntry type="library" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib:1.2.21" level="project" />
     <orderEntry type="library" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="library" name="Gradle: net.java.dev.jna:jna:4.5.0" level="project" />
     <orderEntry type="library" name="Gradle: org.jetbrains:annotations:13.0" level="project" />
   </component>
   <component name="TestModuleProperties" production-module="ps2-klient_main" />

--- a/.idea/modules/ps2-klient_test.iml
+++ b/.idea/modules/ps2-klient_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="ps2-klient:test" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="germanno" external.system.module.type="sourceSet" external.system.module.version="0.1-SNAPSHOT" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="ps2-klient:test" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="germanno" external.system.module.type="sourceSet" external.system.module.version="0.2-SNAPSHOT" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="kotlin-language" name="Kotlin">
       <configuration version="3" platform="JVM 1.8" useProjectSettings="false">

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ repositories {
 
 dependencies {
     compile 'no.tornado:tornadofx:1.7.14'
-    compile 'net.harawata:appdirs:1.0.1'
     compile 'com.github.salomonbrys.kodein:kodein:4.1.0'
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testCompile group: 'junit', name: 'junit', version: '4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 }
 
 group 'germanno'
-version '0.1-SNAPSHOT'
+version '0.2-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'kotlin'

--- a/src/main/kotlin/com/germanno/client/EnvironmentManager.kt
+++ b/src/main/kotlin/com/germanno/client/EnvironmentManager.kt
@@ -5,7 +5,6 @@ import com.germanno.client.interactors.LinuxInteractor
 import com.germanno.client.interactors.MacOsInteractor
 import com.germanno.client.interactors.WindowsInteractor
 import com.sun.javafx.PlatformUtil
-import net.harawata.appdirs.AppDirsFactory
 import tornadofx.*
 import java.io.File
 import java.io.FileOutputStream
@@ -27,18 +26,18 @@ class EnvironmentManager {
                 else                     -> throw IllegalStateException("Operating System is not supported")
             }
 
-    private val appDataDir by lazy {
-        File(AppDirsFactory.getInstance().getUserDataDir("PS2 Klient", null, "GermannoDomingues"))
+    private val workingDir by lazy {
+        File(System.getProperty("java.io.tmpdir"), "PS2Klient")
                 .apply { if (!exists()) mkdirs() }
     }
 
     private val sharedFilesDir by lazy {
-        appDataDir.resolve("sharedFiles")
+        workingDir.resolve("sharedFiles")
                 .apply { if (!exists()) mkdirs() }
     }
 
     private val binaryFile by lazy {
-        appDataDir.resolve(interactor.fileName)
+        workingDir.resolve(interactor.fileName)
     }
 
     private val runningProcesses = mutableSetOf<Process>()

--- a/src/main/kotlin/com/germanno/view/MainController.kt
+++ b/src/main/kotlin/com/germanno/view/MainController.kt
@@ -48,20 +48,21 @@ class MainController : Controller() {
         DirectoryChooser()
                 .apply { title = "Select a folder" }
                 .showDialog(window)
-                ?.let { newFile ->
-                    files.add(newFile.canonicalPath)
-                    environmentManager.shareFile(newFile)
-                }
+                .handleDialogReturn()
     }
 
     fun addFileClicked(window: Window?) {
         FileChooser()
                 .apply { title = "Select a file" }
                 .showOpenDialog(window)
-                ?.let { newFile ->
-                    files.add(newFile.absolutePath)
-                    environmentManager.shareFile(newFile)
-                }
+                .handleDialogReturn()
+    }
+
+    private fun File?.handleDialogReturn() {
+        this?.let { newFile ->
+            environmentManager.shareFile(newFile)
+            updateFileList()
+        }
     }
 
     fun deleteFileClicked(it: KeyEvent) {
@@ -70,11 +71,18 @@ class MainController : Controller() {
                 @Suppress("UNCHECKED_CAST")
                 with(it.source as ListView<String>) {
                     environmentManager.unshareFile(File(selectedItem))
-                    files.remove(selectedItem)
+                    updateFileList()
                 }
             }
             else                               -> {
             }
+        }
+    }
+
+    private fun updateFileList() {
+        files.apply {
+            clear()
+            addAll(environmentManager.listSharedFiles().map { it.canonicalPath })
         }
     }
 


### PR DESCRIPTION
- There's a transitive dependency of AppDirs which apparently has some kind of trojan, as shown here:
https://www.virustotal.com/#/file/617a8d75f66a57296255a13654a99f10f72f0964336e352211247ed046da3e94/detection

- I came to the conclusion that I don't need AppDirs at all, can rely on using native platform temp dir instead

- Added support for storing/reading the filelist on a `.ini` file created in the same folder where the ps2-klient jar is